### PR TITLE
Update field_wbc_importer.js

### DIFF
--- a/wbc_importer/wbc_importer/field_wbc_importer.js
+++ b/wbc_importer/wbc_importer/field_wbc_importer.js
@@ -36,7 +36,12 @@
                 parent.removeClass('active imported').addClass('not-imported');
             }
 
-            parent.find('.spinner').css('display', 'inline-block');
+            parent.find('.spinner').css({
+
+                'display': 'inline-block',
+                'visibility': 'inherit'
+
+                });
 
             parent.removeClass('active imported');
 


### PR DESCRIPTION
Added visibility inherit to address UI bug after WP 4.2

```
 parent.find('.spinner').css({

                'display': 'inline-block',
                'visibility': 'inherit'

                });
```

This will help the spinner to be visible again.
