### PR TITLE
Update field_wbc_importer.css

### DIFF
--- a/wbc_importer/wbc_importer/field_wbc_importer.css
+++ b/wbc_importer/wbc_importer/field_wbc_importer.css
@@ -11,12 +11,13 @@
     max-width: none !important;
     width:100% !important;
 }
-.wbc_importer .theme-browser .theme:focus .more-details, 
+.wbc_importer .theme-browser .theme:focus .more-details,
 .wbc_importer .theme-browser .theme:hover .more-details {
     opacity: 1;
 }
 
 .wbc_importer .theme-browser .theme .spinner {
+    display: none; /*UI fix after WP 4.2*/
     background-position: right center;
     font-size: 12px;
     height: 20px;
@@ -24,8 +25,6 @@
     padding-right: 25px;
     padding-top: 5px;
     width: auto;
-    visibility: visible;
-    display: none;
 }
 
 .wbc_importer .importer-button{


### PR DESCRIPTION
Added display none on line 20 to address UI bug after WP 4.2 otherwise the button looks displaced but after this fix it will be correctly aligned.

```
.wbc_importer .theme-browser .theme .spinner {
    display: none; /*UI fix after WP 4.2*/
}
```
