### PR TITLE
Updated the constructor of wordpress-importer.php

### DIFF
--- a/wbc_importer/inc/importer/wordpress-importer.php
+++ b/wbc_importer/inc/importer/wordpress-importer.php
@@ -63,7 +63,7 @@ class WP_Import extends WP_Importer {
 	var $url_remap = array();
 	var $featured_images = array();
 
-	function WP_Import() { /* nothing */ }
+	function __construct() { /* nothing */ }
 
 	/**
 	 * Registered callback function for the WordPress Importer


### PR DESCRIPTION
I've edited the constructor at line 66 to be compatible with PHP 7.0.13.

It is working for me on PHP 7.0.13. However, I haven't tested it on version 5.6 yet. We might need to add a backward compatibility in case of any errors.