### PR TITLE
Use urls and paths based on the wp-content dir

### DIFF
--- a/wbc_importer/extension_wbc_importer.php
+++ b/wbc_importer/extension_wbc_importer.php
@@ -61,7 +61,7 @@ if ( !class_exists( 'ReduxFramework_extension_wbc_importer' ) ) {
 
             if ( empty( $this->extension_dir ) ) {
                 $this->extension_dir = trailingslashit( str_replace( '\\', '/', dirname( __FILE__ ) ) );
-                $this->extension_url = site_url( str_replace( trailingslashit( str_replace( '\\', '/', ABSPATH ) ), '', $this->extension_dir ) );
+                $this->extension_url = content_url( str_replace( trailingslashit( str_replace( '\\', '/', Redux_Helpers::cleanFilePath( WP_CONTENT_DIR ) ) ), '', $this->extension_dir ) );
                 $this->demo_data_dir = apply_filters( "wbc_importer_dir_path", $this->extension_dir . 'demo-data/' );
             }
 

--- a/wbc_importer/wbc_importer/field_wbc_importer.php
+++ b/wbc_importer/wbc_importer/field_wbc_importer.php
@@ -38,15 +38,15 @@ if ( !class_exists( 'ReduxFramework_wbc_importer' ) ) {
 
             $class = ReduxFramework_extension_wbc_importer::get_instance();
 
-            if ( !empty( $class->demo_data_dir ) ) {
-                $this->demo_data_dir = trailingslashit( str_replace( '\\', '/',  $class->demo_data_dir ) );
-                $this->demo_data_url = site_url( str_replace( trailingslashit( str_replace( '\\', '/', ABSPATH ) ), '', $this->demo_data_dir ) );
-            }
+          if ( !empty( $class->demo_data_dir ) ) {
+            $this->demo_data_dir = trailingslashit( str_replace( '\\', '/',  $class->demo_data_dir ) );
+            $this->demo_data_url = content_url( str_replace( trailingslashit( str_replace( '\\', '/', Redux_Helpers::cleanFilePath( WP_CONTENT_DIR ) ) ), '', $this->demo_data_dir ) );
+          }
 
-            if ( empty( $this->extension_dir ) ) {
-                $this->extension_dir = trailingslashit( str_replace( '\\', '/', dirname( __FILE__ ) ) );
-                $this->extension_url = site_url( str_replace( trailingslashit( str_replace( '\\', '/', ABSPATH ) ), '', $this->extension_dir ) );
-            }
+          if ( empty( $this->extension_dir ) ) {
+            $this->extension_dir = trailingslashit( str_replace( '\\', '/', dirname( __FILE__ ) ) );
+            $this->extension_url = content_url( str_replace( trailingslashit( str_replace( '\\', '/', Redux_Helpers::cleanFilePath( WP_CONTENT_DIR ) ) ), '', $this->extension_dir ) );
+          }
         }
 
         /**


### PR DESCRIPTION
In WP installations where the wp-content directory is not inside the ABSPATH (wordpress core root) the paths and URLS for the demos are incorrect. 
Replaced usage of site_url and ABSPATH with content_url and WP_CONTENT_DIR to determine the locations based on the wp-content directory.